### PR TITLE
Fixed topic post number being incorrect if we're not on page 1.

### DIFF
--- a/flaskbb/templates/forum/topic.html
+++ b/flaskbb/templates/forum/topic.html
@@ -38,7 +38,7 @@
         <tr>
             <td >
                 <span class="pull-right">
-                    <strong>#{%- if posts.page == 1 -%} {{ loop.index }} {%- else -%} {{ loop.index + posts.page * per_page }} {%- endif -%}</strong>
+                    <strong>#{%- if posts.page == 1 -%} {{ loop.index }} {%- else -%} {{ loop.index + (posts.page - 1) * per_page }} {%- endif -%}</strong>
                 </span>
                 <span class="pull-left">
                     <a href="


### PR DESCRIPTION
Page one on a topic was showing posts as 1, 2, 3, 4 .. up to 10, then page 2 was starting at 21 instead of 11.  This fixes that problem.
