### PR TITLE
BUG: Topics pagination does not work

### DIFF
--- a/flaskbb/utils/query.py
+++ b/flaskbb/utils/query.py
@@ -134,7 +134,7 @@ class TopicQuery(BaseQuery):
 
         # No need to count if we're on the first page and there are fewer
         # items than we expected.
-        if page == 1 and len(items) < per_page:
+        if page == 1 and len(self.all()) < per_page:
             total = len(items)
         else:
             total = self.order_by(None).count()


### PR DESCRIPTION
The length considered below should not be that of the 'items',
rather, it should be of all the results
