### PR TITLE
Fix server error when save private message with To User do not exist

### DIFF
--- a/flaskbb/user/views.py
+++ b/flaskbb/user/views.py
@@ -165,7 +165,7 @@ def new_message():
     to_user = request.args.get("to_user")
 
     if request.method == "POST":
-        if "save_message" in request.form:
+        if "save_message" in request.form and form.validate():
             to_user = User.query.filter_by(username=form.to_user.data).first()
 
             form.save(from_user=current_user.id,


### PR DESCRIPTION
There will be a server error when forum user try to save a private message with To User do not exist. 

Here is  the reproduce steps:
1. login the forum
2. write a new private message
3. in the "To User" field, enter some random user name which do not exist
4. fill other field as necessary
5. click "save as draft"

finally, the server error happend.

![image](https://cloud.githubusercontent.com/assets/6936127/4938476/c6dda968-65cb-11e4-83de-bf8bf62f71ff.png)
