### PR TITLE
Add direct link to reported post on report management pages

### DIFF
--- a/flaskbb/templates/management/reports.html
+++ b/flaskbb/templates/management/reports.html
@@ -33,7 +33,7 @@
         <tbody>
             {% for report in reports.items %}
             <tr>
-                <td>{{ report.id }}</td>
+                <td><a href="{{ url_for('forum.view_post', post_id=report.post.id) }}" target="_blank">{{ report.id }}</a></td>
                 <td>{{ report.post.user.username }}</td>
                 <td>{{ report.post.topic.title }}</td>
                 <td>{{ report.reporter.username }}</td>

--- a/flaskbb/templates/management/unread_reports.html
+++ b/flaskbb/templates/management/unread_reports.html
@@ -34,7 +34,7 @@
         <tbody>
             {% for report in reports.items %}
             <tr>
-                <td>{{ report.id }}</td>
+                <td><a href="{{ url_for('forum.view_post', post_id=report.post.id) }}" target="_blank">{{ report.id }}</a></td>
                 <td>{{ report.post.user.username }}</td>
                 <td>{{ report.post.topic.title }}</td>
                 <td>{{ report.reporter.username }}</td>


### PR DESCRIPTION
A small addition that will make life easier for administrators - as they won't have to track down the reported post themselves anymore.
