### PR TITLE
Don't delete topics when they are untracked

### DIFF
--- a/flaskbb/user/models.py
+++ b/flaskbb/user/models.py
@@ -156,7 +156,6 @@ class User(db.Model, UserMixin, CRUDMixin):
         primaryjoin=(topictracker.c.user_id == id),
         backref=db.backref("topicstracked", lazy="dynamic"),
         lazy="dynamic",
-        cascade="all, delete-orphan",
         single_parent=True
     )
 

--- a/tests/unit/test_forum_models.py
+++ b/tests/unit/test_forum_models.py
@@ -401,6 +401,23 @@ def test_topic_tracker_needs_update(database, user, topic):
         assert topic.tracker_needs_update(forumsread, topicsread)
 
 
+def test_untracking_topic_does_not_delete_it(database, user, topic):
+    user.track_topic(topic)
+    user.save()
+    user.untrack_topic(topic)
+
+    # Note that instead of returning None from the query below, the
+    # unpatched verson will actually raise a DetachedInstanceError here,
+    # due to the fact that some relationships don't get configured in
+    # tests correctly and deleting would break them or something.  The
+    # test still fails for the same reason, however: the topic gets
+    # (albeit unsuccessfully) deleted when it is removed from
+    # topictracker, when it clearly shouldn't be.
+    user.save()
+
+    assert Topic.query.filter(Topic.id == topic.id).first()
+
+
 def test_topic_tracker_needs_update_cleared(database, user, topic):
     """Tests if the topicsread needs an update if the forum has been marked
     as cleared.


### PR DESCRIPTION
Due to a ``cascade="all"`` on the ``User``'s ``tracked_topics`` relationship, removing topics from the topic tracker causes them to be deleted, as of the current master.

This bug got introduced in https://github.com/flaskbb/flaskbb/commit/a55e6f71b270167960a0c2fd0cded30f78414e01, the fateful one-line change obscured by copious code reformatting. Yikes.

I'm glad it only took me a single topic wrongly deleted to catch this.

Test included.