### PR TITLE
Ensure logging path is wrapped in quotes when provided

### DIFF
--- a/flaskbb/configs/config.cfg.template
+++ b/flaskbb/configs/config.cfg.template
@@ -171,7 +171,11 @@ ADMINS = ["{{ mail_admin_address }}"]
 # and the default logging setting.
 #
 # If set to a file path, this should be an absolute file path
-LOG_CONF_FILE = {{ log_config_path or None }}
+{% if log_config_path %}
+LOG_CONF_FILE = "{{ log_config_path }}"
+{% else %}
+LOG_CONF_FILE = None
+{% endif %}
 
 # Path to store the INFO and ERROR logs
 # If None this defaults to flaskbb/logs


### PR DESCRIPTION
Gonna tag this v2.0.2 after merge. Not sure how this slipped by in the initial testing.