### PR TITLE
Fix celery blocking thread

### DIFF
--- a/flaskbb/configs/default.py
+++ b/flaskbb/configs/default.py
@@ -265,6 +265,7 @@ class DefaultConfig(object):
     # Celery
     CELERY_BROKER_URL = 'redis://localhost:6379'
     CELERY_RESULT_BACKEND = 'redis://localhost:6379'
+    BROKER_TRANSPORT_OPTIONS = {'max_retries': 1}  # necessary as there's no default
 
 
     # FlaskBB Settings


### PR DESCRIPTION
After https://github.com/celery/kombu/commit/816e3dcf346decd4d458e2a088ac7a914b48dcce, celery will retry failed connections to the broker (I think that's the correct terminology, correct me if not). Unfortunately, they don't define the maximum number of retries, meaning that if the worker isn't running, the calls will block forever.

For flaskBB, this manifests in requests to `celerystatus` never returning if celery isn't running. On a production setup, this means that every time the management panel is accessed, another worker thread dies. Eventually all worker threads are exhausted and the forum stops responding entirely.

(I assume the same is true for requests to the password reset form, but I haven't tested that.)

This patch sets the cap to 1, meaning that if the first connection doesn't succeed, celery won't try again. I think that's sufficient for the basic setup we ship by default; if the user has a more involved celery configuration, they can override this setting.