### PR TITLE
Nicer posts & topics display on user pages

### DIFF
--- a/flaskbb/templates/user/all_posts.html
+++ b/flaskbb/templates/user/all_posts.html
@@ -16,9 +16,7 @@
     {% for post in posts.items %}
     <div class="panel page-panel">
         <div class="panel-heading page-head topic-head">
-            {# no attribute access in translated strings #}
-            {% set topic_title = post.topic.title %}
-            <a href="{{ post.url }}">{% trans %}In topic <strong>{{ topic_title }}</strong>{% endtrans %}</a>
+            <a href="{{ post.url }}">{% trans topic_title=post.topic.title %}In topic <strong>{{ topic_title }}</strong>{% endtrans %}</a>
         </div>
         <div class="panel-body page-body topic-content">
             <div class="col-md-12 col-sm-12 col-xs-12">

--- a/flaskbb/templates/user/all_posts.html
+++ b/flaskbb/templates/user/all_posts.html
@@ -9,15 +9,16 @@
 </ul>
 {% endblock %}
 
-
 {% block profile_content %}
 <!-- middle column -->
 <div class="col-md-9 col-sm-9 col-xs-12 profile-content">
 
     {% for post in posts.items %}
     <div class="panel page-panel">
-        <div class="panel-heading page-head">
-            <a href="{{ post.topic.url }}">{{ post.topic.title }}</a>
+        <div class="panel-heading page-head topic-head">
+            {# no attribute access in translated strings #}
+            {% set topic_title = post.topic.title %}
+            <a href="{{ post.url }}">{% trans %}In topic <strong>{{ topic_title }}</strong>{% endtrans %}</a>
         </div>
         <div class="panel-body page-body topic-content">
             <div class="col-md-12 col-sm-12 col-xs-12">
@@ -34,13 +35,13 @@
     <div class="row">
         <div class="col-md-12 col-sm-12 col-xs-12">
             <div class="alert-message alert-message-info" role="alert">
-                {% trans %}The user has not written any posts yet.{% endtrans %}
+                {% trans %}No posts yet{% endtrans %}
             </div>
         </div>
     </div>
     {% endfor %}
 
-    {% if posts.items|length > 1 %}
+    {% if posts.items %}
     <div class="col-md-12 col-sm-12 col-xs-12 controls-col">
         <div class="pull-left">
             {{ render_pagination(posts, url_for('user.view_all_posts', username=user.username)) }}

--- a/flaskbb/templates/user/all_topics.html
+++ b/flaskbb/templates/user/all_topics.html
@@ -16,12 +16,15 @@
     {% for topic in topics.items %}
     <div class="panel page-panel">
         <div class="panel-heading page-head topic-head">
-            {# no attribute access in translated strings #}
-            {% set topic_url = topic.url %}
-            {% set topic_title = topic.title %}
-            {% set forum_url = topic.forum.url %}
-            {% set forum_title = topic.forum.title %}
-            {% trans %}<strong><a href="{{ topic_url }}">{{ topic_title }}</a></strong> in forum <a href="{{ forum_url }}">{{ forum_title }}</a>{% endtrans %}
+            {% trans trimmed
+                topic_url=topic.url,
+                topic_title=topic.title,
+                forum_url=topic.forum.url,
+                forum_title=topic.forum.title
+            %}
+                <strong><a href="{{ topic_url }}">{{ topic_title }}</a></strong>
+                in forum <a href="{{ forum_url }}">{{ forum_title }}</a>
+            {% endtrans %}
         </div>
         <div class="panel-body page-body topic-content">
             <div class="col-md-12 col-sm-12 col-xs-12">

--- a/flaskbb/templates/user/all_topics.html
+++ b/flaskbb/templates/user/all_topics.html
@@ -14,35 +14,37 @@
 <div class="col-md-9 col-sm-9 col-xs-12 profile-content">
 
     {% for topic in topics.items %}
-
     <div class="panel page-panel">
         <div class="panel-heading page-head topic-head">
-            <strong><a href="{{ topic.url }}">{{ topic.title }}</a></strong> in <a href="{{ topic.forum.url }}">{{ topic.forum.title }}</a>
+            {# no attribute access in translated strings #}
+            {% set topic_url = topic.url %}
+            {% set topic_title = topic.title %}
+            {% set forum_url = topic.forum.url %}
+            {% set forum_title = topic.forum.title %}
+            {% trans %}<strong><a href="{{ topic_url }}">{{ topic_title }}</a></strong> in forum <a href="{{ forum_url }}">{{ forum_title }}</a>{% endtrans %}
         </div>
-
         <div class="panel-body page-body topic-content">
             <div class="col-md-12 col-sm-12 col-xs-12">
                 <div class="topic-created">
                     {{ topic.date_created|format_datetime }}
                 </div>
                 <div class="topic-content">
-                {{ topic.first_post.content|markup }}
+                    {{ topic.first_post.content|markup }}
                 </div>
             </div>
         </div>
     </div>
-
     {% else %}
     <div class="row">
-        <div class="col-md-12 col-sm-12 co-xs-12">
+        <div class="col-md-12 col-sm-12 col-xs-12">
             <div class="alert-message alert-message-info" role="alert">
-                {% trans %}The user has not opened any topics yet.{% endtrans %}
+                {% trans %}No topics yet{% endtrans %}
             </div>
         </div>
-    </div> <!-- end forum-row -->
+    </div>
     {% endfor %}
 
-    {% if topics.items|length > 1 %}
+    {% if topics.items %}
     <div class="col-md-12 col-sm-12 col-xs-12 controls-col">
         <div class="pull-left">
             {{ render_pagination(topics, url_for('user.view_all_topics', username=user.username)) }}

--- a/flaskbb/user/models.py
+++ b/flaskbb/user/models.py
@@ -292,30 +292,29 @@ class User(db.Model, UserMixin, CRUDMixin):
         return self
 
     def all_topics(self, page, viewer):
-        """Returns a paginated result with all topics the user has created.
+        """Topics made by a given user, most recent first.
 
         :param page: The page which should be displayed.
-        :param viewer: The user who is viewing this user. It will return a
-                       list with topics that the *viewer* has access to and
-                       thus it will not display all topics from
-                       the requested user.
+        :param viewer: The user who is viewing the page. Only posts
+                       accessible to the viewer will be returned.
+        :rtype: flask_sqlalchemy.Pagination
         """
         group_ids = [g.id for g in viewer.groups]
         topics = Topic.query.\
             filter(Topic.user_id == self.id,
                    Forum.id == Topic.forum_id,
                    Forum.groups.any(Group.id.in_(group_ids))).\
+            order_by(Topic.id.desc()).\
             paginate(page, flaskbb_config['TOPICS_PER_PAGE'], False)
         return topics
 
     def all_posts(self, page, viewer):
-        """Returns a paginated result with all posts the user has created.
+        """Posts made by a given user, most recent first.
 
         :param page: The page which should be displayed.
-        :param viewer: The user who is viewing this user. It will return a
-                       list with posts that the *viewer* has access to and
-                       thus it will not display all posts from
-                       the requested user.
+        :param viewer: The user who is viewing the page. Only posts
+                       accessible to the viewer will be returned.
+        :rtype: flask_sqlalchemy.Pagination
         """
         group_ids = [g.id for g in viewer.groups]
         posts = Post.query.\
@@ -323,6 +322,7 @@ class User(db.Model, UserMixin, CRUDMixin):
                    Post.topic_id == Topic.id,
                    Topic.forum_id == Forum.id,
                    Forum.groups.any(Group.id.in_(group_ids))).\
+            order_by(Post.id.desc()).\
             paginate(page, flaskbb_config['TOPICS_PER_PAGE'], False)
         return posts
 


### PR DESCRIPTION
I was working on a 'Liked posts' feature in [one of my addons](https://github.com/micha030201/flaskbb-plugin-vanity) when I noticed a few issues in the way flaskbb handles posted content on user pages currently. This pull request is meant to fix the issues I've discovered.

A summary of changes introduced in this PR:

- make a couple of strings translatable
- fix the bug where page navigation wouldn't display if the last page had only a single post
- change sort order to put the most recent posts on the first page
- change links to lead to the post itself rather than its topic