### PR TITLE
Fix plugin translations never getting loaded

### DIFF
--- a/flaskbb/utils/translations.py
+++ b/flaskbb/utils/translations.py
@@ -65,7 +65,7 @@ class FlaskBBDomain(Domain):
                     domain="messages"
                 )
 
-                if not type(plugin_translation) == babel.support.NullTranslations:
+                if type(plugin_translation) is not babel.support.NullTranslations:
                     translations.add(plugin_translation)
 
             self.cache[str(locale)] = translations

--- a/flaskbb/utils/translations.py
+++ b/flaskbb/utils/translations.py
@@ -65,8 +65,7 @@ class FlaskBBDomain(Domain):
                     domain="messages"
                 )
 
-                if not isinstance(plugin_translation,
-                                  babel.support.NullTranslations):
+                if not type(plugin_translation) == babel.support.NullTranslations:
                     translations.add(plugin_translation)
 
             self.cache[str(locale)] = translations


### PR DESCRIPTION
[`babel.support.Translations` is a subclass of `babel.support.NullTranslations`](https://github.com/python-babel/babel/blob/d2cf189ff0ce505b46191268c3cbdc4b130d8dd6/babel/support.py#L525), thus the `isinstance` check always returns `True` and plugin translations are never loaded.

Fixed by comparing concrete types rather than including the entire inheritance tree.

I'd love to be able to write a test for this, but it seems like there's no testing machinery in place for either plugins or translations, and I don't have it in me to create it myself.