### PR TITLE
Allow customization of the inline and block lexers for mistune

### DIFF
--- a/flaskbb/markup.py
+++ b/flaskbb/markup.py
@@ -89,7 +89,10 @@ def flaskbb_load_nonpost_inline_class():
 def flaskbb_jinja_directives(app):
     render_classes = app.pluggy.hook.flaskbb_load_post_markdown_class(app=app)
     lexer_classes = app.pluggy.hook.flaskbb_load_post_inline_class(app=app)
-    app.jinja_env.filters['markup'] = make_renderer(render_classes, lexer_classes)
+    app.jinja_env.filters['markup'] = make_renderer(
+        render_classes,
+        lexer_classes
+    )
 
     render_classes = app.pluggy.hook.flaskbb_load_nonpost_markdown_class(
         app=app

--- a/flaskbb/markup.py
+++ b/flaskbb/markup.py
@@ -125,9 +125,11 @@ def make_renderer(render_classes, inline_classes, block_classes):
     InlineCls = type('FlaskBBInlineLexer', tuple(inline_classes), {})
     BlockCls = type('FlaskBBBlockLexer', tuple(block_classes), {})
 
-    renderer = RenderCls(escape=True, hard_wrap=True)
-    inline = InlineCls(renderer)
-    block = BlockCls()
+    kwargs = {'escape': True, 'hard_wrap': True}
+
+    renderer = RenderCls(**kwargs)
+    inline = InlineCls(renderer, **kwargs)
+    block = BlockCls(**kwargs)
 
     markup = mistune.Markdown(renderer=renderer, inline=inline, block=block)
     return lambda text: Markup(markup.render(text))

--- a/flaskbb/plugins/spec.py
+++ b/flaskbb/plugins/spec.py
@@ -132,6 +132,19 @@ def flaskbb_load_nonpost_markdown_class(app):
     :type app: Flask
     """
 
+@spec
+def flaskbb_load_post_inline_class(app):
+    """
+    See flaskbb_load_post_markdown_class. Provides the inline lexer class for
+    posts.
+    """
+
+def flaskbb_load_nonpost_inline_class(app):
+    """
+    See flaskbb_load_post_markdown_class. Provides the inline lexer class for
+    non-post areas.
+    """
+
 
 @spec
 def flaskbb_cli(cli, app):

--- a/flaskbb/plugins/spec.py
+++ b/flaskbb/plugins/spec.py
@@ -149,6 +149,21 @@ def flaskbb_load_nonpost_inline_class(app):
 
 
 @spec
+def flaskbb_load_post_block_class(app):
+    """
+    See flaskbb_load_post_markdown_class. Provides the block lexer class for
+    posts.
+    """
+
+
+def flaskbb_load_nonpost_block_class(app):
+    """
+    See flaskbb_load_post_markdown_class. Provides the block lexer class for
+    non-post areas.
+    """
+
+
+@spec
 def flaskbb_cli(cli, app):
     """Hook for registering CLI commands.
 

--- a/flaskbb/plugins/spec.py
+++ b/flaskbb/plugins/spec.py
@@ -132,12 +132,14 @@ def flaskbb_load_nonpost_markdown_class(app):
     :type app: Flask
     """
 
+
 @spec
 def flaskbb_load_post_inline_class(app):
     """
     See flaskbb_load_post_markdown_class. Provides the inline lexer class for
     posts.
     """
+
 
 def flaskbb_load_nonpost_inline_class(app):
     """

--- a/tests/unit/utils/test_markup.py
+++ b/tests/unit/utils/test_markup.py
@@ -1,6 +1,8 @@
 from flaskbb.markup import FlaskBBRenderer, make_renderer
+from mistune import InlineLexer, BlockLexer
 
-markdown = make_renderer([FlaskBBRenderer])
+
+markdown = make_renderer([FlaskBBRenderer], [InlineLexer], [BlockLexer])
 
 
 def test_custom_renderer():


### PR DESCRIPTION
The current pluggy hooks only allow modification of the renderer class. These commits add hooks that work in the same way to allow modification of the inline and block lexers.