### PR TITLE
Add ability to upgrade plugin settings without a full reinstall cycle

### DIFF
--- a/flaskbb/templates/management/plugins.html
+++ b/flaskbb/templates/management/plugins.html
@@ -72,6 +72,14 @@
                                 {% trans %}Uninstall{% endtrans %}
                             </button>
                         </form>
+                        {% if plugin.has_new_settings() %}
+                        <form class="inline-form" method="post" action="{{ url_for('management.upgrade_plugin', name=plugin.name) }}">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                            <button class="btn btn-info" name="confirmDialog" data-toggle="tooltip" data-placement="top" title="Upgrades the settings">
+                                {% trans %}Upgrade{% endtrans %}
+                            </button>
+                        </form>
+                        {% endif %}
 
                         <a class="btn btn-info" href="{{ url_for('management.settings', plugin=plugin.name) }}">Settings</a>
                         {% endif %}


### PR DESCRIPTION
Early Feedback for #508 

Currently only covers the upgrade portion, though I have open questions on individually upgraded settings -- some things are trivial display name, description, default, are easy to reconcile as the underlying data doesn't change, but change in extras or value type could bork things. We might consider adding a "deprecated" to the settings object that accepts a version string for when the setting will be removed and not allow changing the value type (just ignore it, I guess? no sense in punishing users, but then again that could result in a broken upgrade).

Still working out what the hooks look like, but those'll be inbound by next weekend (assuming nothing comes up with work).