### PR TITLE
Update Werkzeug, but not to the newest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ SQLAlchemy-Utils==0.34.2
 Unidecode==1.1.1
 urllib3==1.25.6
 vine==1.3.0
-Werkzeug==0.16.0
+Werkzeug>=0.14.1,<1.0.0
 Whoosh==2.7.4
 WTForms==2.2.1
 -e .

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ install_requires = [
     "Unidecode>=1.0.22",
     "urllib3>=1.23",
     "vine>=1.1.4",
-    "Werkzeug>=0.14.1",
+    "Werkzeug==0.16.1",
     "Whoosh>=2.7.4",
     "WTForms>=2.2.1",
 ]

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ install_requires = [
     "Unidecode>=1.0.22",
     "urllib3>=1.23",
     "vine>=1.1.4",
-    "Werkzeug==0.16.1",
+    "Werkzeug>=0.14.1<1.0.0",
     "Whoosh>=2.7.4",
     "WTForms>=2.2.1",
 ]


### PR DESCRIPTION
The newest Werkzeug has some breaking changes.  While we should probably upgrade to it eventually, for now upgrading to pre-1.0 seems to work.