### PR TITLE
Bump SQLAlchemy version to 1.3.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ requests==2.24.0
 simplejson==3.17.0
 six==1.15.0
 speaklater==1.3
-SQLAlchemy==1.3.18
+SQLAlchemy==1.3.20
 SQLAlchemy-Utils==0.36.8
 Unidecode==1.1.1
 urllib3==1.25.9


### PR DESCRIPTION
According to Requires.io [0] the SQLAlchemy 1.3.18 is insecure. This
patch bump version to 1.3.20. Even if, there are some outdated
requirements version, SQLAlchemy is the only marked as insecure.

[0] https://requires.io/github/flaskbb/flaskbb/requirements/?branch=master