### PR TITLE
Fix link to documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ Links
 -----
 
 `website <https://flaskbb.org>`_ |
-`documentation <https://flaskbb.readthedocs.org/en/latest/index.html/>`_ |
+`documentation <https://flaskbb.readthedocs.org/en/latest/index.html>`_ |
 `source code <https://github.com/sh4nks/flaskbb>`_
 
 


### PR DESCRIPTION
Removes a trailing slash in the link to documentation that was sending 
it to a nonexistent page instead of the correct one.