### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -260,7 +260,7 @@ or::
 
     flaskbb install
 
-During the installation process, you will be asked to provide a username, email adddress 
+During the installation process, you will be asked to provide a username, email address 
 and password for your administrator user. Using the
 ``make install`` command is recommended as it checks that the dependencies
 are also installed.

--- a/flaskbb/core/auth/registration.py
+++ b/flaskbb/core/auth/registration.py
@@ -68,7 +68,7 @@ class RegistrationFailureHandler(ABC):
 
 class RegistrationPostProcessor(ABC):
     """
-    Used to post proccess successful registrations by the time this
+    Used to post process successful registrations by the time this
     interface is called, the user has already been persisted into the
     database.
     """

--- a/flaskbb/core/tokens.py
+++ b/flaskbb/core/tokens.py
@@ -117,7 +117,7 @@ class TokenSerializer(ABC):
 
 class TokenVerifier(ABC):
     """
-    Used to verify the validatity of tokens post
+    Used to verify the validity of tokens post
     deserialization, such as an email matching the
     user id in the provided token.
 

--- a/flaskbb/plugins/spec.py
+++ b/flaskbb/plugins/spec.py
@@ -284,7 +284,7 @@ def flaskbb_gather_registration_validators():
     :class:`~flaskbb.core.auth.registration.UserRegistrationInfo` and raises
     a :class:`~flaskbb.core.exceptions.ValidationError` if the registration
     is invalid or :class:`~flaskbb.core.exceptions.StopValidation` if
-    validation of the registration should end immediatey.
+    validation of the registration should end immediately.
 
     Example::
 

--- a/tests/unit/test_forum_models.py
+++ b/tests/unit/test_forum_models.py
@@ -579,7 +579,7 @@ def test_forumsread(topic, user):
 
 
 def test_topicsread(topic, user):
-    """Tests if the topicsread trakcer can be saved/edited and deleted with the
+    """Tests if the topicsread tracker can be saved/edited and deleted with the
     implemented save and delete methods."""
     topicsread = TopicsRead()
     topicsread.user_id = user.id


### PR DESCRIPTION
There are small typos in:
- docs/installation.rst
- flaskbb/core/auth/registration.py
- flaskbb/core/tokens.py
- flaskbb/plugins/spec.py
- tests/unit/test_forum_models.py

Fixes:
- Should read `validity` rather than `validatity`.
- Should read `tracker` rather than `trakcer`.
- Should read `process` rather than `proccess`.
- Should read `immediately` rather than `immediatey`.
- Should read `address` rather than `adddress`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md