### PR TITLE
Fix birthday field validation

### DIFF
--- a/flaskbb/management/forms.py
+++ b/flaskbb/management/forms.py
@@ -78,7 +78,7 @@ class UserForm(FlaskForm):
     password = PasswordField("Password", validators=[
         DataRequired()])
 
-    birthday = DateField(_("Birthday"), format="%d %m %Y", validators=[
+    birthday = DateField(_("Birthday"), format="%Y-%m-%d", validators=[
         Optional()])
 
     gender = StringField(_("Gender"), validators=[Optional()])

--- a/flaskbb/user/forms.py
+++ b/flaskbb/user/forms.py
@@ -105,7 +105,7 @@ class ChangePasswordForm(FlaskBBForm):
 
 
 class ChangeUserDetailsForm(FlaskBBForm):
-    birthday = DateField(_("Birthday"), format="%d %m %Y", validators=[Optional()])
+    birthday = DateField(_("Birthday"), format="%Y-%m-%d", validators=[Optional()])
     gender = StringField(_("Gender"), validators=[Optional()])
     location = StringField(_("Location"), validators=[Optional()])
     website = StringField(_("Website"), validators=[Optional(), URL()])


### PR DESCRIPTION
The format string for the birthday field was incorrect. [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#value) says it's supposed to be `yyyy-mm-dd`, which agrees with with what Firefox and Chromium are sending on my machine.

The bad format meant that any attempt to update a users account details (via the admin controls or the user's own settings page) would silently do nothing if they tried to set their birthday.

This PR fixes it and makes the birthday field work.