### PR TITLE
Fix quote ajax url (fixes flaskbb/flaskbb#631)

### DIFF
--- a/flaskbb/themes/aurora/src/app/flaskbb.js
+++ b/flaskbb/themes/aurora/src/app/flaskbb.js
@@ -190,7 +190,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 typeof FORUM_URL_PREFIX !== typeof undefined
                     ? FORUM_URL_PREFIX
                     : "";
-            const url = `${urlprefix}post/${post_id}/raw`;
+            const url = `${urlprefix}/post/${post_id}/raw`;
 
             const editor = document.querySelector(".flaskbb-editor");
             fetch(url)


### PR DESCRIPTION
This requires rebuilding the theme with `npm run build` but I've left the build artefacts out of the commit as I'm unsure the process around that (and I only have pnpm on my machine right now, so my build is slightly different).

I have tested and confirmed this fixes the issue though.