### PR TITLE
Small fixes

### DIFF
--- a/flaskbb/plugins/manager.py
+++ b/flaskbb/plugins/manager.py
@@ -102,7 +102,7 @@ class FlaskBBPluginManager(pluggy.PluginManager):
             try:
                 plugin = ep.load()
             except DistributionNotFound:
-                logger.warn("Could not load plugin {}. Passing."
+                logger.warning("Could not load plugin {}. Passing."
                             .format(ep.name))
                 continue
             except VersionConflict as e:

--- a/flaskbb/themes/aurora/build_emoji_set.py
+++ b/flaskbb/themes/aurora/build_emoji_set.py
@@ -8,7 +8,7 @@ URL = 'https://unicode.org/Public/emoji/{}/emoji-test.txt'.format(sys.argv[1])
 
 
 def get_annotations():
-    resp = requests.get(URL)
+    resp = requests.get(URL, timeout=(3.05, 27))
     resp.raise_for_status()
     for line in resp.text.split('\n'):
         match = re.match('(.+?); fully-qualified +?# .+? (.+)', line)

--- a/flaskbb/utils/helpers.py
+++ b/flaskbb/utils/helpers.py
@@ -539,7 +539,7 @@ def get_image_info(url):
     """
 
     try:
-        r = requests.get(url, stream=True)
+        r = requests.get(url, timeout=(3.05, 27), stream=True)
     except requests.ConnectionError:
         return None
 

--- a/flaskbb/utils/helpers.py
+++ b/flaskbb/utils/helpers.py
@@ -467,7 +467,7 @@ def _format_html_time_tag(datetime, what_to_display):
 
     return Markup(
         '<time datetime="{}" data-what_to_display="{}">{}</time>'.format(
-            isoformat, what_to_display, content, content
+            isoformat, what_to_display, content
         )
     )
 


### PR DESCRIPTION
**Issues reported by the Pylint tool**
- In `flaskbb/flaskbb/utils/helpers.py:469`
  - Too many arguments for format string, duplicate string formatting argument 'content'.
- In `flaskbb/flaskbb/plugins/manager.py:105`
  - Using deprecated method warn(), replaced with logger.warnning()

**Issues reported by the Bandit tool**
- In `flaskbb/flaskbb/themes/aurora/build_emoji_set.py:11` and `flaskbb/flaskbb/utils/helpers.py:542`
  - Request call without timeout (https://bandit.readthedocs.io/en/1.7.5/plugins/b113_request_without_timeout.html)